### PR TITLE
Fix jshint errors

### DIFF
--- a/dist/html-exports.js
+++ b/dist/html-exports.js
@@ -109,7 +109,7 @@
 })(this.HTMLExports = this.HTMLExports || {})
 
 ;(function(scope) {
-
+  'use strict'
   scope.DocumentLoader.mixin(System)
 
 })(this.HTMLExports = this.HTMLExports || {})

--- a/src/base.js
+++ b/src/base.js
@@ -1,6 +1,7 @@
 // # HTMLExports
 
 ;(function(scope) {
+  'use strict'
 
   // TODO(nevir)
   scope.depsFor = function depsFor(document) {

--- a/src/system.js
+++ b/src/system.js
@@ -1,4 +1,5 @@
 ;(function(scope) {
+  'use strict'
 
   scope.DocumentLoader.mixin(System)
 


### PR DESCRIPTION
Noticed there were a few missing `use strict` statements in the source according to jshint. Added them.
